### PR TITLE
sample commit add OpenSSL::Provider module

### DIFF
--- a/ext/openssl/ossl.c
+++ b/ext/openssl/ossl.c
@@ -1271,6 +1271,7 @@ Init_openssl(void)
     Init_ossl_x509();
     Init_ossl_ocsp();
     Init_ossl_engine();
+    Init_ossl_provider();
     Init_ossl_asn1();
     Init_ossl_kdf();
 

--- a/ext/openssl/ossl.h
+++ b/ext/openssl/ossl.h
@@ -62,6 +62,10 @@
 # define OSSL_USE_ENGINE
 #endif
 
+#if !defined(OSSL_USE_ENGINE) && OSSL_OPENSSL_PREREQ(3, 0, 0)
+# define OSSL_USE_PROVIDER
+#endif
+
 /*
  * Common Module
  */
@@ -194,6 +198,7 @@ void ossl_debug(const char *, ...);
 #endif
 #include "ossl_x509.h"
 #include "ossl_engine.h"
+#include "ossl_provider.h"
 #include "ossl_kdf.h"
 
 void Init_openssl(void);

--- a/ext/openssl/ossl_provider.c
+++ b/ext/openssl/ossl_provider.c
@@ -1,0 +1,37 @@
+#include "ossl.h"
+
+#ifdef OSSL_USE_PROVIDER
+# include <openssl/provider.h>
+#endif
+
+VALUE mProvider;
+VALUE eProviderError;
+
+static VALUE
+ossl_provider_s_load(VALUE self, VALUE name)
+{
+    OSSL_PROVIDER *provider = NULL;
+
+    const char *provider_name_ptr = StringValueCStr(name);
+
+    provider = OSSL_PROVIDER_load(NULL, provider_name_ptr);
+    if (provider == NULL) {
+      ossl_raise(eProviderError, "Failed to load %s provider\n", provider_name_ptr);
+      return Qfalse;
+    }
+
+    return Qtrue;
+}
+
+void
+Init_ossl_provider(void)
+{
+#if 0
+    mOSSL = rb_define_module("OpenSSL");
+    eOSSLError = rb_define_class_under(mOSSL, "OpenSSLError", rb_eStandardError);
+#endif
+
+    mProvider = rb_define_module_under(mOSSL, "Provider");
+    eProviderError = rb_define_class_under(mProvider, "ProviderError", eOSSLError);
+    rb_define_module_function(mProvider, "load", ossl_provider_s_load, 1);
+}

--- a/ext/openssl/ossl_provider.h
+++ b/ext/openssl/ossl_provider.h
@@ -1,0 +1,8 @@
+#if !defined(OSSL_PROVIDER_H)
+#define OSSL_PROVIDER_H
+
+extern VALUE mProvider;
+extern VALUE eProviderError;
+
+void Init_ossl_provider(void);
+#endif

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -2,6 +2,16 @@
 require_relative 'utils'
 if defined?(OpenSSL)
 class OpenSSL::TestProvider < OpenSSL::TestCase
+  def test_openssl_providers
+    with_openssl <<-'end;'
+      orig = OpenSSL::Provider.providers
+      loaded_legacy = OpenSSL::Provider.load("legacy")
+      
+      assert_equal(true, loaded_legacy)
+      assert_equal(1, OpenSSL::Provider.providers.size - orig.size)
+    end;
+  end
+
   def test_openssl_provider_cipher_rc4
     with_openssl(<<-'end;', ignore_stderr: true)
       OpenSSL::Provider.load("legacy")

--- a/test/openssl/test_provider.rb
+++ b/test/openssl/test_provider.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require_relative 'utils'
+if defined?(OpenSSL)
+class OpenSSL::TestProvider < OpenSSL::TestCase
+  def test_openssl_provider_cipher_rc4
+    with_openssl(<<-'end;', ignore_stderr: true)
+      OpenSSL::Provider.load("legacy")
+      algo = "RC4"
+      data = "a" * 1000
+      key = OpenSSL::Random.random_bytes(16)
+      
+      cipher = OpenSSL::Cipher.new(algo)
+      cipher.encrypt
+      cipher.key = key
+      encrypted = cipher.update(data) + cipher.final
+      
+      cipher.decrypt
+      cipher.key = key
+      decrypted = cipher.update(encrypted) + cipher.final
+
+      assert_equal(data, decrypted)
+    end;
+  end
+
+  private
+
+  # this is required because OpenSSL::Provider methods change global state
+  def with_openssl(code, **opts)
+    assert_separately([{ "OSSL_MDEBUG" => nil }, "-ropenssl"], <<~"end;", **opts)
+      #{code}
+    end;
+  end
+end
+
+end


### PR DESCRIPTION
`ruby/openssl` にOpenSSL3のproviderを設定できるAPIを生やしたい。のとりあえずの実装。

- [ ] `OpenSSL::Provider`のクラス化
  - [ ] 必要なAPIの設計
  - [ ] メモリ周りの知識
- [ ] `OpenSSL::Provider.providers`の実装
  - [ ] `OSSL_PROVIDER_do_all()`を使えばいけそう


参考リンク
https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER.html
https://www.openssl.org/docs/manmaster/man7/provider.html
https://github.com/openssl/openssl/blob/0bf7e94c10f1b00510b8a36cdcbedc02a66468be/README-PROVIDERS.md#L4